### PR TITLE
🎨 Adjust square size and placement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/scripts/heatmap.js
+++ b/scripts/heatmap.js
@@ -187,7 +187,7 @@ datasource.then(function (data) {
   // Add subtitle to graph
   svg
     .append("a")
-    .attr("xlink:href", `https://github.com/FCP-INDI/C-PAC/tree/${dataSha}`)
+    .attr("xlink:href", `https://github.com/FCP-INDI/C-PAC/commit/${dataSha}`)
     .append("text")
     .attr("x", -yLabelWidth)
     .attr("y", -(xLabelWidth + 20))


### PR DESCRIPTION
<h2><span id="description" name="description">Description</span></h2>

- [x] Makes width of graph based on number of columns rather than the width of one column
- [x] Reduces the size of the squares and removes padding between them
- [x] Increases the opacity of the squares to `1` so background doesn't affect the color of the squares
- [x] Rounds the correlation values to nearest ten‒millionth (we can adjust that here https://github.com/shnizzedy/dashboard/blob/7030811bb6bac69f8c0a3859aa3215331deafb34/scripts/heatmap.js#L133 or in the correlations script, but going out like 20 decimal places seems disingenuous to me)
- [x] Makes tooltip invisible before first mouseover
- [x] Highlights the currently‒moused‒over square grey
- [x] Makes the SHA subtitle a link to that commit

<span id="screenshots" name="screenshots"></span>
## Screenshots

<span id="before" name="before"></span>
### before

![large overlapping squares](https://github.com/user-attachments/assets/2fc150cf-0039-4299-b415-4ae26fdf06d9)

<span id="after" name="after"></span>
### after

![tight grid](https://github.com/user-attachments/assets/021d3168-52e3-46d8-a11c-948cb45bb3a3)
